### PR TITLE
Use boolean array for marked abilities

### DIFF
--- a/src/character-tracker.ts
+++ b/src/character-tracker.ts
@@ -21,7 +21,7 @@ export class CharacterTracker implements ReadonlyMap<string, CharacterResult> {
       key: string,
       map: ReadonlyMap<string, CharacterResult>,
     ) => void,
-    thisArg?: any,
+    thisArg?: unknown,
   ): void {
     this.index.forEach(callbackfn, thisArg);
   }
@@ -57,19 +57,27 @@ export class CharacterTracker implements ReadonlyMap<string, CharacterResult> {
 
   activeCharacter(): [string, CharacterContext] {
     if (this.size == 0) {
-      throw new Error("no valid characters found");
+      throw new MissingCharacterError("no valid characters found");
     } else if (this.size > 1) {
-      throw new Error("we don't yet support multiple characters");
+      throw new MissingCharacterError(
+        "we don't yet support multiple characters",
+      );
     }
 
     const [[key, val]] = this.entries();
     if (val.isLeft()) {
-      throw new Error("character is invalid", { cause: val.error });
+      throw val.error;
     }
 
     return [key, val.value];
   }
 }
+
+export class CharacterError extends Error {}
+
+export class MissingCharacterError extends Error {}
+
+export class InvalidCharacterError extends Error {}
 
 export class CharacterIndexer extends BaseIndexer<CharacterResult> {
   readonly id: string = "character";

--- a/src/characters/action-context.ts
+++ b/src/characters/action-context.ts
@@ -134,6 +134,14 @@ export class CharacterActionContext implements IActionContext {
 
 export type ActionContext = CharacterActionContext | NoCharacterActionConext;
 
+function renderError(e: Error, el: HTMLElement): void {
+  el.createEl("pre", { text: `${e.name}: ${e.message}` });
+  if (e.cause instanceof Error) {
+    el.createEl("p", { text: "Caused by:" });
+    renderError(e.cause, el);
+  }
+}
+
 export async function determineCharacterActionContext(
   plugin: ForgedPlugin,
 ): Promise<ActionContext | undefined> {
@@ -147,11 +155,19 @@ export async function determineCharacterActionContext(
         characterContext,
       );
     } catch (e) {
-      // TODO: probably want to show character parse errors in full glory
-      await InfoModal.show(
-        plugin.app,
-        `An error occurred while finding your active character.\n\n${e}`,
-      );
+      const div = document.createElement("div");
+      div.createEl("p", {
+        text: `An error occurred while finding your active character`,
+      });
+      if (e instanceof Error) {
+        renderError(e, div);
+      } else {
+        div.createEl("pre", {
+          text: `${e}`,
+        });
+      }
+
+      await InfoModal.show(plugin.app, div);
       return undefined;
     }
   } else {

--- a/src/characters/lens.test.ts
+++ b/src/characters/lens.test.ts
@@ -146,16 +146,25 @@ describe("characterLens", () => {
     const character = validater({
       ...VALID_INPUT,
       assets: [
-        { id: "asset_id", controls: { integrity: 2 } },
+        {
+          id: "asset_id",
+          abilities: [true, false, false],
+          controls: { integrity: 2 },
+        },
       ] as ForgedSheetAssetInput[],
     });
     actsLikeLens(lens.assets, character, [
-      { id: "new_asset", controls: { integrity: 3 }, options: {} },
+      {
+        id: "new_asset",
+        abilities: [true, false, false],
+        controls: { integrity: 3 },
+        options: {},
+      },
     ]);
 
     it("requires a valid asset definition", () => {
       expect(() =>
-        lens.assets.update(character, [{ foo: "bar" }] as any),
+        lens.assets.update(character, [{ foo: "bar" }] as never),
       ).toThrow(/invalid_type/);
     });
 
@@ -405,11 +414,17 @@ describe("movesReader", () => {
         movesReader(lens, mockIndex).get(
           validater({
             ...VALID_INPUT,
-            assets: [{ id: "starforged/assets/path/empath" }],
+            assets: [
+              {
+                id: "starforged/assets/path/empath",
+                abilities: [false, false, false],
+              },
+            ],
           } satisfies BaseForgedSchema),
         ),
       ).toEqual(Right.create([]));
     });
+
     it("includes moves for marked asset abilities", () => {
       // This ability has no additional moves.
       expect(
@@ -418,7 +433,10 @@ describe("movesReader", () => {
             validater({
               ...VALID_INPUT,
               assets: [
-                { id: "starforged/assets/path/empath", marked_abilities: [2] },
+                {
+                  id: "starforged/assets/path/empath",
+                  abilities: [false, true, false],
+                },
               ],
             } satisfies BaseForgedSchema),
           )
@@ -434,7 +452,7 @@ describe("movesReader", () => {
               assets: [
                 {
                   id: "starforged/assets/path/empath",
-                  marked_abilities: [1, 2],
+                  abilities: [true, true, false],
                 },
               ],
             } satisfies BaseForgedSchema),

--- a/src/utils/ui/info.ts
+++ b/src/utils/ui/info.ts
@@ -4,7 +4,7 @@ import { type App } from "obsidian";
 
 /** Modal to render an informative prompt to the user. */
 export class InfoModal extends Modal {
-  static async show(app: App, content: string): Promise<void> {
+  static async show(app: App, content: string | HTMLElement): Promise<void> {
     return await new Promise((resolve, _reject) => {
       new this(app, content, resolve).open();
     });
@@ -12,7 +12,7 @@ export class InfoModal extends Modal {
 
   private constructor(
     app: App,
-    public readonly content: string,
+    public readonly content: string | HTMLElement,
     public readonly accept: () => void,
   ) {
     super(app);


### PR DESCRIPTION
Switches from `marked_abilities: [1,2]` to `abilities: [true, true, false]` for asset abilities representation.

(Since this will break existing characters with assets, it also adds very slightly more useful error messages when loading an invalid character)

Fixes #16