### PR TITLE
Use ProgressTrack in progress renderer

### DIFF
--- a/src/mechanics/mechanics-blocks.ts
+++ b/src/mechanics/mechanics-blocks.ts
@@ -5,8 +5,9 @@ import {
   MarkdownRenderer,
 } from "obsidian";
 
-import ForgedPlugin from "../index";
 import { MoveModal } from "moves/move-modal";
+import { ProgressTrack } from "tracks/progress";
+import ForgedPlugin from "../index";
 
 export default function registerMechanicsBlock(plugin: ForgedPlugin): void {
   plugin.registerMarkdownCodeBlockProcessor(
@@ -306,22 +307,31 @@ export class MechanicsRenderer {
 
   async renderProgress(target: HTMLElement, node: KdlNode) {
     const trackName = (node.properties.name ?? node.values[0]) as string;
-    let from = node.properties.from as number;
-    const fromBoxes =
-      (node.properties["from-boxes"] as number) ??
-      (from != null ? Math.floor(from / 4) : 0);
-    const fromTicks =
-      (node.properties["from-ticks"] as number) ??
-      (from != null ? from % 4 : 0);
-    if (from == null) {
-      from = fromBoxes * 4 + fromTicks;
+    const result = ProgressTrack.create({
+      progress:
+        node.properties.from ??
+        ((node.properties["from-boxes"] as number) ?? 0) * 4 +
+          ((node.properties["from-ticks"] as number) ?? 0),
+      difficulty: node.properties.level,
+      unbounded: (node.properties.unbounded ?? false) as boolean,
+      complete: false,
+    });
+    if (result.isLeft()) {
+      // todo: Better error display
+      target.createEl("pre", {
+        text: `Invalid track:\n${result.error.toString()}`,
+        cls: "error",
+      });
+      return;
     }
-    const level = (node.properties.level ?? node.values[2]) as string;
+    const startTrack = result.value;
+
+    const [fromBoxes, fromTicks] = startTrack.boxesAndTicks();
+    const level = startTrack.difficulty;
     const steps = (node.properties.steps ?? node.values[3] ?? 1) as number;
-    const delta = levelTicks(level) * steps;
-    const to = from + delta;
-    const toBoxes = Math.floor(to / 4);
-    const toTicks = to % 4;
+
+    const endTrack = startTrack.advanced(steps);
+    const [toBoxes, toTicks] = endTrack.boxesAndTicks();
     await this.renderDlist(target, "progress", {
       "Track Name": { cls: "track-name", value: trackName, md: true },
       Steps: {
@@ -613,29 +623,4 @@ function rollOutcome(
     text: outcome,
     match: challenge1 === challenge2,
   };
-}
-
-enum Level {
-  Troublesome = 12,
-  Dangerous = 8,
-  Formidable = 4,
-  Extreme = 2,
-  Epic = 1,
-}
-
-function levelTicks(level: string): number {
-  switch (level.toLowerCase()) {
-    case "troublesome":
-      return Level.Troublesome;
-    case "dangerous":
-      return Level.Dangerous;
-    case "formidable":
-      return Level.Formidable;
-    case "extreme":
-      return Level.Extreme;
-    case "epic":
-      return Level.Epic;
-    default:
-      return 0;
-  }
 }

--- a/src/tracks/progress.test.ts
+++ b/src/tracks/progress.test.ts
@@ -34,6 +34,21 @@ describe("ProgressTrack", () => {
     });
   });
 
+  it("interprets the difficulty case insensitively", () => {
+    const result = ProgressTrack.create({
+      ...TEST_DATA,
+      difficulty: "DANGERous",
+    });
+    expect(result.isRight()).toBeTruthy();
+    const track = result.unwrap();
+    expect(track).toMatchObject<ProgressTrackSchema>({
+      difficulty: ChallengeRanks.Dangerous,
+      progress: 10,
+      complete: false,
+      unbounded: false,
+    });
+  });
+
   it.each([
     {
       rank: ChallengeRanks.Dangerous,

--- a/src/tracks/progress.ts
+++ b/src/tracks/progress.ts
@@ -6,32 +6,35 @@ import { Either, Left, Right } from "../utils/either";
 
 export enum ChallengeRanks {
   /** 12 ticks per step */
-  Troublesome = "Troublesome",
+  Troublesome = "troublesome",
 
   /** 8 ticks per step */
-  Dangerous = "Dangerous",
+  Dangerous = "dangerous",
 
   /** 4 ticks per step */
-  Formidable = "Formidable",
+  Formidable = "formidable",
 
   /** 2 ticks per step */
-  Extreme = "Extreme",
+  Extreme = "extreme",
 
   /** 1 tick per step */
-  Epic = "Epic",
+  Epic = "epic",
 }
 
 export const CHALLENGE_STEPS: Record<ChallengeRanks, number> = {
-  Troublesome: 12,
-  Dangerous: 8,
-  Formidable: 4,
-  Extreme: 2,
-  Epic: 1,
+  [ChallengeRanks.Troublesome]: 12,
+  [ChallengeRanks.Dangerous]: 8,
+  [ChallengeRanks.Formidable]: 4,
+  [ChallengeRanks.Extreme]: 2,
+  [ChallengeRanks.Epic]: 1,
 };
 
 export const MAX_TICKS = 40;
 
-export const challengeRankSchema = z.nativeEnum(ChallengeRanks);
+export const challengeRankSchema = z.preprocess(
+  (val) => (typeof val === "string" ? val.toLowerCase() : val),
+  z.nativeEnum(ChallengeRanks),
+);
 
 export const progressTrackerSchema = z
   .object({
@@ -126,6 +129,10 @@ export class ProgressTrack {
 
   get boxesFilled(): number {
     return Math.floor(this.progress / 4);
+  }
+
+  boxesAndTicks(): [number, number] {
+    return [this.boxesFilled, this.progress - this.boxesFilled * 4];
   }
 
   /** Number of boxes filled to count for progress rolls.


### PR DESCRIPTION
Switches the `progress` node renderer to use the `ProgressTrack` class for progress calculations.

This fixes cases where steps could take tracks past 10 boxes.

Also adds support for unbounded tracks (like the legacy tracks) with an optional `unbounded` boolean property.