### PR TITLE
Wire up the sidebar oracles

### DIFF
--- a/src/oracles/command.ts
+++ b/src/oracles/command.ts
@@ -60,6 +60,7 @@ export async function runOracleCommand(
   datastore: Datastore,
   editor: Editor,
   _view: MarkdownView,
+  chosenOracle?: Oracle,
 ): Promise<void> {
   if (!datastore.ready) {
     console.warn("data not ready");
@@ -101,17 +102,22 @@ export async function runOracleCommand(
     return;
   }
 
-  const oracles: Oracle[] = [...datastore.oracles.values()];
-  const oracle = await CustomSuggestModal.select(
-    app,
-    oracles,
-    formatOraclePath,
-    (match, el) => {
-      const ruleset = oracleRuleset(match.item);
-      el.createEl("small", { text: ruleset, cls: "forged-suggest-hint" });
-    },
-    prompt ? `Select an oracle to answer '${prompt}'` : "Select an oracle",
-  );
+  let oracle: Oracle;
+  if (chosenOracle) {
+    oracle = chosenOracle;
+  } else {
+    const oracles: Oracle[] = [...datastore.oracles.values()];
+    oracle = await CustomSuggestModal.select(
+      app,
+      oracles,
+      formatOraclePath,
+      (match, el) => {
+        const ruleset = oracleRuleset(match.item);
+        el.createEl("small", { text: ruleset, cls: "forged-suggest-hint" });
+      },
+      prompt ? `Select an oracle to answer '${prompt}'` : "Select an oracle",
+    );
+  }
   console.log(oracle);
   const rollContext = new OracleRoller(datastore.oracles);
   new OracleRollerModal(

--- a/src/oracles/oracle-modal.ts
+++ b/src/oracles/oracle-modal.ts
@@ -25,7 +25,6 @@ export class OracleModal extends Modal {
         .onClick(() => {
           const { workspace } = this.plugin.app;
           const view = workspace.getActiveFileView();
-          console.log({ view });
           if (view && view instanceof MarkdownView) {
             const editor = view.editor;
             runOracleCommand(

--- a/src/oracles/oracle-modal.ts
+++ b/src/oracles/oracle-modal.ts
@@ -24,16 +24,18 @@ export class OracleModal extends Modal {
         .setTooltip("Roll this Oracle")
         .onClick(() => {
           const { workspace } = this.plugin.app;
-          const editor = workspace.activeEditor?.editor;
-          const view = workspace.getActiveViewOfType(MarkdownView);
-          console.log({ editor, view });
-          if (editor && view) {
+          const view = workspace.getActiveFileView();
+          console.log({ view });
+          if (view && view instanceof MarkdownView) {
+            const editor = view.editor;
             runOracleCommand(
               this.plugin.app,
               this.plugin.datastore,
               editor,
               view,
+              oracle,
             );
+            this.close();
           }
         });
       const table = contentEl.createEl("table");


### PR DESCRIPTION
Looks like `Workspace.getActiveFileView()` does what we want-- seems to track the last editor that the cursor was in! I'm wondering if it's the same underlying thing used by the left File sidebar-- that definitely has the behavior that we want, so if this doesn't work out, figuring that out via the JS debugger may be a next step.