### PR TITLE
Use lowercase for clock and progress track keys

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
       "fileMatch": ["/data/*"],
       "url": "./node_modules/@datasworn/core/json/datasworn.schema.json"
     }
-  ]
+  ],
+  "eslint.experimental.useFlatConfig": true
 }

--- a/src/tracks/clock-file.ts
+++ b/src/tracks/clock-file.ts
@@ -8,9 +8,9 @@ import { Clock } from "./clock";
 
 const clockSchema = z
   .object({
-    Name: z.string(),
-    Segments: z.number().positive(),
-    Progress: z.number().positive(),
+    name: z.string(),
+    segments: z.number().positive(),
+    progress: z.number().positive(),
     tags: z
       .union([z.string().transform((arg) => [arg]), z.array(z.string())])
       .refine(
@@ -26,7 +26,7 @@ const clockSchema = z
             "Tags must contain exactly one of 'incomplete' or 'complete'",
         },
       ),
-    ClockImage: z.string().optional(),
+    clockimage: z.string().optional(),
   })
   .passthrough();
 
@@ -40,7 +40,7 @@ export class ClockFileAdapter {
   ) {}
 
   get name(): string {
-    return this.raw.Name;
+    return this.raw.name;
   }
 
   static create(
@@ -51,8 +51,8 @@ export class ClockFileAdapter {
     if (result.success) {
       const raw = result.data;
       return Clock.create({
-        progress: raw.Progress,
-        segments: raw.Segments,
+        progress: raw.progress,
+        segments: raw.segments,
         active: !raw.tags.includes("complete"),
       }).map((clock) => new this(raw, clock, clockImageGenerator));
     } else {
@@ -68,9 +68,9 @@ export class ClockFileAdapter {
     if (this.clock == other || this.clock.equals(other)) return this;
     return new ClockFileAdapter(
       produce(this.raw, (data) => {
-        data.Progress = other.progress;
-        data.ClockImage = this.clockImageGenerator(other);
-        data.Segments = other.segments;
+        data.progress = other.progress;
+        data.clockimage = this.clockImageGenerator(other);
+        data.segments = other.segments;
         const [tagToRemove, tagToAdd] = !other.active
           ? ["incomplete", "complete"]
           : ["complete", "incomplete"];

--- a/src/tracks/clock-file.ts
+++ b/src/tracks/clock-file.ts
@@ -1,5 +1,6 @@
 import { produce } from "immer";
 import { CachedMetadata } from "obsidian";
+import { normalizeKeys } from "utils/zodutils";
 import { z } from "zod";
 import { BaseIndexer } from "../indexer/indexer";
 import { Either, Left } from "../utils/either";
@@ -30,6 +31,8 @@ const clockSchema = z
   })
   .passthrough();
 
+export const normalizedClockSchema = normalizeKeys(clockSchema);
+
 export type ClockSchema = z.output<typeof clockSchema>;
 
 export class ClockFileAdapter {
@@ -47,7 +50,7 @@ export class ClockFileAdapter {
     data: unknown,
     clockImageGenerator: (track: Clock) => string,
   ): Either<z.ZodError, ClockFileAdapter> {
-    const result = clockSchema.safeParse(data);
+    const result = normalizedClockSchema.safeParse(data);
     if (result.success) {
       const raw = result.data;
       return Clock.create({

--- a/src/tracks/progress.test.ts
+++ b/src/tracks/progress.test.ts
@@ -220,7 +220,7 @@ describe("ProgressTrackFileAdapter", () => {
       const updated = original.updatingTrack((track) =>
         track.advancedByTicks(10),
       );
-      expect(updated.raw.Progress).toBe(original.raw.Progress + 10);
+      expect(updated.raw.progress).toBe(original.raw.progress + 10);
     });
 
     it("updates the track image", () => {
@@ -228,8 +228,8 @@ describe("ProgressTrackFileAdapter", () => {
       const updated = original.updatingTrack((track) =>
         track.advancedByTicks(10),
       );
-      expect(updated.raw.TrackImage).toBe(
-        `[[progress-track-${original.raw.Progress + 10}.svg]]`,
+      expect(updated.raw.trackimage).toBe(
+        `[[progress-track-${original.raw.progress + 10}.svg]]`,
       );
     });
 
@@ -246,7 +246,7 @@ describe("ProgressTrackFileAdapter", () => {
         make_({ foo: "bar", baz: { bop: 1 } }).updatingTrack((track) =>
           track.advanced(1),
         ).raw,
-      ).toMatchObject({ Progress: 18, foo: "bar", baz: { bop: 1 } });
+      ).toMatchObject({ progress: 18, foo: "bar", baz: { bop: 1 } });
     });
   });
 });

--- a/src/tracks/progress.ts
+++ b/src/tracks/progress.ts
@@ -1,5 +1,6 @@
 import { produce } from "immer";
 import { CachedMetadata } from "obsidian";
+import { normalizeKeys } from "utils/zodutils";
 import { ZodError, z } from "zod";
 import { BaseIndexer } from "../indexer/indexer";
 import { Either, Left, Right } from "../utils/either";
@@ -37,42 +38,40 @@ export const challengeRankSchema = z.preprocess(
 );
 
 /** Schema for progress track files. */
-export const baseProgressTrackerSchema = z
-  .object({
-    Name: z.string(),
-    rank: challengeRankSchema,
-    Progress: z.number().int().nonnegative().default(0),
-    tags: z
-      .union([z.string().transform((arg) => [arg]), z.array(z.string())])
-      .refine(
-        (arg) => {
-          const hasComplete = arg.includes("complete");
-          const hasIncomplete = arg.includes("incomplete");
-          return (
-            (hasComplete && !hasIncomplete) || (hasIncomplete && !hasComplete)
-          );
-        },
-        {
-          message:
-            "Tags must contain exactly one of 'incomplete' or 'complete'",
-        },
-      ),
-    TrackImage: z.string(),
-    tracktype: z.string(),
-  })
-  .passthrough();
+export const baseProgressTrackerSchema = z.object({
+  name: z.string(),
+  rank: challengeRankSchema,
+  progress: z.number().int().nonnegative().default(0),
+  tags: z
+    .union([z.string().transform((arg) => [arg]), z.array(z.string())])
+    .refine(
+      (arg) => {
+        const hasComplete = arg.includes("complete");
+        const hasIncomplete = arg.includes("incomplete");
+        return (
+          (hasComplete && !hasIncomplete) || (hasIncomplete && !hasComplete)
+        );
+      },
+      {
+        message: "Tags must contain exactly one of 'incomplete' or 'complete'",
+      },
+    ),
+  trackimage: z.string(),
+  tracktype: z.string(),
+});
 
 export const progressTrackerSchema = z.union([
-  baseProgressTrackerSchema,
-  baseProgressTrackerSchema
-    .omit({ rank: true })
-    .merge(
-      z.object({
-        Difficulty: baseProgressTrackerSchema.shape.rank,
-      }),
-    )
-    .passthrough()
-    .transform(({ Difficulty, ...rest }) => ({ ...rest, rank: Difficulty })),
+  normalizeKeys(baseProgressTrackerSchema.passthrough()),
+  normalizeKeys(
+    baseProgressTrackerSchema
+      .omit({ rank: true })
+      .merge(
+        z.object({
+          difficulty: baseProgressTrackerSchema.shape.rank,
+        }),
+      )
+      .passthrough(),
+  ).transform(({ difficulty, ...rest }) => ({ ...rest, rank: difficulty })),
 ]);
 
 export type ProgressTrackerInputSchema = z.input<typeof progressTrackerSchema>;
@@ -215,7 +214,7 @@ export class ProgressTrackFileAdapter implements ProgressTrackInfo {
   ) {}
 
   get name(): string {
-    return this.raw.Name;
+    return this.raw.name;
   }
 
   get trackType(): string {
@@ -232,11 +231,11 @@ export class ProgressTrackFileAdapter implements ProgressTrackInfo {
   ): Either<ZodError, ProgressTrackFileAdapter> {
     return this.create(
       {
-        Name: name,
+        name,
         rank: track.rank,
-        Progress: track.progress,
+        progress: track.progress,
         tags: track.complete ? ["complete"] : ["incomplete"],
-        TrackImage: settings.generateTrackImage(track),
+        trackimage: settings.generateTrackImage(track),
         tracktype,
         forgedkind: "progress",
       } as ProgressTrackerInputSchema,
@@ -253,7 +252,7 @@ export class ProgressTrackFileAdapter implements ProgressTrackInfo {
       const raw = result.data;
       return ProgressTrack.create({
         rank: raw.rank,
-        progress: raw.Progress,
+        progress: raw.progress,
         complete: raw.tags.includes("complete"),
         unbounded: false,
       }).map((track) => new this(raw, track, settings));
@@ -272,8 +271,8 @@ export class ProgressTrackFileAdapter implements ProgressTrackInfo {
     if (this.track == other || this.track.equals(other)) return this;
     return new ProgressTrackFileAdapter(
       produce(this.raw, (data) => {
-        data.Progress = other.progress;
-        data.TrackImage = this.settings.generateTrackImage(other);
+        data.progress = other.progress;
+        data.trackimage = this.settings.generateTrackImage(other);
         data.rank = other.rank;
         const [tagToRemove, tagToAdd] = other.complete
           ? ["incomplete", "complete"]
@@ -310,7 +309,6 @@ export class ProgressIndexer extends BaseIndexer<ProgressTrackFileAdapter> {
     cache: CachedMetadata,
   ): ProgressTrackFileAdapter | undefined {
     // TODO: we should use our Either support now to handle this
-    // TODO: customize track image gen
     return ProgressTrackFileAdapter.create(
       cache.frontmatter,
       this.settings,

--- a/src/tracks/writer.ts
+++ b/src/tracks/writer.ts
@@ -1,4 +1,5 @@
 import { updating } from "utils/lens";
+import { ObjectProcessor } from "utils/obsidian";
 import { CharacterContext } from "../character-tracker";
 import { updater } from "../utils/update";
 import {
@@ -19,9 +20,7 @@ export class ProgressTrackFileWriter implements ProgressTrackWriterContext {
   constructor(
     public readonly adapter: ProgressTrackFileAdapter,
     public readonly settings: ProgressTrackSettings,
-    public readonly processor: (
-      process: (data: unknown) => object,
-    ) => Promise<void>,
+    public readonly processor: ObjectProcessor,
     public readonly location: string,
   ) {}
   async process(
@@ -46,9 +45,7 @@ export class ProgressTrackFileWriter implements ProgressTrackWriterContext {
 export class LegacyTrackWriter implements ProgressTrackWriterContext {
   constructor(
     public readonly character: CharacterContext,
-    public readonly processor: (
-      process: (data: unknown) => object,
-    ) => Promise<void>,
+    public readonly processor: ObjectProcessor,
     public readonly trackKey: string,
     public readonly location: string,
   ) {}

--- a/src/utils/obsidian.ts
+++ b/src/utils/obsidian.ts
@@ -29,7 +29,7 @@ export function pluginAsset(plug: Plugin, assetPath: string): string {
 // }
 
 export type ObjectProcessor = (
-  processor: (data: Record<string, any>) => Record<string, any>,
+  processor: (data: Record<string, unknown>) => Record<string, unknown>,
 ) => Promise<void>;
 
 export function vaultProcess(
@@ -44,7 +44,7 @@ export function vaultProcess(
     }
     await app.fileManager.processFrontMatter(
       file,
-      (frontmatter: Record<string, any>) => {
+      (frontmatter: Record<string, unknown>) => {
         const originalKeys = Object.keys(frontmatter);
         const updated = processor(frontmatter);
         if (frontmatter === updated) return;

--- a/src/utils/obsidian.ts
+++ b/src/utils/obsidian.ts
@@ -28,19 +28,36 @@ export function pluginAsset(plug: Plugin, assetPath: string): string {
 //   };
 // }
 
+export type ObjectProcessor = (
+  processor: (data: Record<string, any>) => Record<string, any>,
+) => Promise<void>;
+
 export function vaultProcess(
   app: App,
   path: string,
-): (processor: (data: unknown) => object) => Promise<void> {
+  processDeletes: boolean = true,
+): ObjectProcessor {
   return async (processor) => {
     const file = app.vault.getAbstractFileByPath(path);
     if (!(file instanceof TFile)) {
       throw new Error(`invalid character file ${path}`);
     }
-    await app.fileManager.processFrontMatter(file, (frontmatter: object) => {
-      const updated = processor(frontmatter);
-      // TODO: this isn't actually going to work right... for deletes
-      Object.assign(frontmatter, updated);
-    });
+    await app.fileManager.processFrontMatter(
+      file,
+      (frontmatter: Record<string, any>) => {
+        const originalKeys = Object.keys(frontmatter);
+        const updated = processor(frontmatter);
+        if (frontmatter === updated) return;
+
+        if (processDeletes) {
+          for (const originalKey of originalKeys) {
+            if (!(originalKey in updated)) {
+              delete frontmatter[originalKey];
+            }
+          }
+        }
+        Object.assign(frontmatter, updated);
+      },
+    );
   };
 }

--- a/src/utils/update.ts
+++ b/src/utils/update.ts
@@ -2,7 +2,7 @@ import { ObjectProcessor } from "./obsidian";
 
 export function updater<T>(
   fromData: (data: object) => T,
-  toData: (obj: T) => Record<string, any>,
+  toData: (obj: T) => Record<string, unknown>,
 ): (process: ObjectProcessor, updater: (obj: T) => T) => Promise<T> {
   return async (process, updater) => {
     let updated: T | undefined;
@@ -17,7 +17,7 @@ export function updater<T>(
 
 export function updaterWithContext<T, U>(
   fromData: (data: object) => T,
-  toData: (obj: T) => object,
+  toData: (obj: T) => Record<string, unknown>,
   context: U,
 ): (
   process: ObjectProcessor,
@@ -25,7 +25,7 @@ export function updaterWithContext<T, U>(
 ) => Promise<T> {
   return async (process, updater) => {
     let updated: T | undefined;
-    await process((data: unknown) => {
+    await process((data: Record<string, unknown>) => {
       updated = updater(
         fromData(Object.freeze(Object.assign({}, data))),
         context,

--- a/src/utils/update.ts
+++ b/src/utils/update.ts
@@ -1,10 +1,9 @@
+import { ObjectProcessor } from "./obsidian";
+
 export function updater<T>(
   fromData: (data: object) => T,
-  toData: (obj: T) => object,
-): (
-  process: (processer: (data: unknown) => object) => Promise<void>,
-  updater: (obj: T) => T,
-) => Promise<T> {
+  toData: (obj: T) => Record<string, any>,
+): (process: ObjectProcessor, updater: (obj: T) => T) => Promise<T> {
   return async (process, updater) => {
     let updated: T | undefined;
     await process((data: unknown) => {
@@ -21,7 +20,7 @@ export function updaterWithContext<T, U>(
   toData: (obj: T) => object,
   context: U,
 ): (
-  process: (processer: (data: unknown) => object) => Promise<void>,
+  process: ObjectProcessor,
   updater: (obj: T, context: U) => T,
 ) => Promise<T> {
   return async (process, updater) => {

--- a/src/utils/zodutils.test.ts
+++ b/src/utils/zodutils.test.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import { normalizeKeys } from "./zodutils";
+
+describe("normalizeKeys", () => {
+  const schema = z.object({
+    alllower: z.string(),
+    mixedCase: z.string(),
+  });
+
+  describe("when using the schema", () => {
+    const normalizedSchema = normalizeKeys(schema);
+    it("accepts keys of the original case", () => {
+      expect(
+        normalizedSchema.parse({ alllower: "val1", mixedCase: "val2" }),
+      ).toEqual({
+        alllower: "val1",
+        mixedCase: "val2",
+      });
+    });
+    it("accepts keys of different case", () => {
+      expect(
+        normalizedSchema.parse({ AllLower: "val1", MIXEDcase: "val2" }),
+      ).toEqual({
+        alllower: "val1",
+        mixedCase: "val2",
+      });
+    });
+  });
+  describe("on a strict schema", () => {
+    const normalizedSchema = normalizeKeys(schema.strict());
+    it("does not permit additional keys on a non-passthrough schema", () => {
+      expect(
+        normalizedSchema.safeParse({
+          allLower: "val1",
+          mixedCase: "val2",
+          otherKey: "val3",
+        }),
+      ).toMatchObject({ success: false });
+    });
+  });
+  describe("on a passthrough schema", () => {
+    const normalizedSchema = normalizeKeys(schema.passthrough());
+    it("passes additional keys unmodifid", () => {
+      expect(
+        normalizedSchema.parse({
+          AllLower: "val1",
+          MixedCase: "val2",
+          otherKey: "val3",
+        }),
+      ).toEqual({
+        alllower: "val1",
+        mixedCase: "val2",
+        otherKey: "val3",
+      });
+    });
+  });
+});

--- a/src/utils/zodutils.ts
+++ b/src/utils/zodutils.ts
@@ -25,8 +25,8 @@ export function normalizeKeys<
 ): z.ZodPipeline<
   z.ZodEffects<
     z.ZodRecord<z.ZodString, z.ZodAny>,
-    { [k: string]: any },
-    Record<string, any>
+    { [k: string]: unknown },
+    Record<string, unknown>
   >,
   z.ZodObject<T, UnknownKeys, Catchall, Output, Input>
 > {

--- a/src/utils/zodutils.ts
+++ b/src/utils/zodutils.ts
@@ -13,3 +13,41 @@ export function zodResultToEither<Input, Output>(
     return Left.create(result.error);
   }
 }
+
+export function normalizeKeys<
+  T extends z.ZodRawShape,
+  UnknownKeys extends z.UnknownKeysParam = z.UnknownKeysParam,
+  Catchall extends z.ZodTypeAny = z.ZodTypeAny,
+  Output = z.objectOutputType<T, Catchall, UnknownKeys>,
+  Input = z.objectInputType<T, Catchall, UnknownKeys>,
+>(
+  schema: z.ZodObject<T, UnknownKeys, Catchall, Output, Input>,
+): z.ZodPipeline<
+  z.ZodEffects<
+    z.ZodRecord<z.ZodString, z.ZodAny>,
+    { [k: string]: any },
+    Record<string, any>
+  >,
+  z.ZodObject<T, UnknownKeys, Catchall, Output, Input>
+> {
+  const allowedKeys = new Map(
+    Object.keys(schema.shape).map((key) => [key.toLowerCase(), key]),
+  );
+
+  return z
+    .record(z.string(), z.any())
+    .transform((rec) =>
+      Object.fromEntries(
+        Object.entries(rec).map((entry) => {
+          const thisKey = entry[0].toLowerCase();
+          const allowedKey = allowedKeys.get(thisKey);
+          if (allowedKey) {
+            return [allowedKey, entry[1]];
+          } else {
+            return entry;
+          }
+        }),
+      ),
+    )
+    .pipe(schema);
+}

--- a/test-vault/Clocks/Test Clock.md
+++ b/test-vault/Clocks/Test Clock.md
@@ -1,11 +1,11 @@
 ---
-Name: Destruction of Kresnik
-Segments: 8
-Progress: 6
 tags:
   - incomplete
-ClockImage: "[[progress-clock-8-6.svg]]"
 forgedkind: clock
+name: Destruction of Kresnik
+segments: 8
+progress: 7
+clockimage: "[[progress-clock-8-7.svg]]"
 ---
 
 # `=this.Name`

--- a/test-vault/Progress/Example Vow.md
+++ b/test-vault/Progress/Example Vow.md
@@ -1,12 +1,12 @@
 ---
-Name: Example vow
-Difficulty: Troublesome
-Progress: 24
 tags:
   - incomplete
-TrackImage: "[[progress-track-24.svg]]"
 forgedkind: progress
 tracktype: Vow
+name: Example vow
+progress: 24
+trackimage: "[[progress-track-24.svg]]"
+rank: troublesome
 ---
 
 # Example vow


### PR DESCRIPTION
Introduces a zod helper `normalizeKeys` that allows us to make case-insensitive object schemas, which this uses to preserve backwards compatibility.

Fixes #56