### PR TITLE
Make progress track creation folder configurable

### DIFF
--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -1,7 +1,7 @@
+import Emittery from "emittery";
 import Handlebars from "handlebars";
 import { ClockFileAdapter } from "tracks/clock-file";
 import { ProgressTrackFileAdapter, ProgressTrackInfo } from "tracks/progress";
-import Emittery from "emittery";
 
 export class ForgedPluginSettings {
   advanceProgressTemplate: string =
@@ -13,6 +13,8 @@ export class ForgedPluginSettings {
   createClockTemplate: string =
     "> [!progress] [[{{clockPath}}|{{clockInfo.name}}]] clock created\n>**Progress:** {{clockInfo.clock.progress}} out of {{clockInfo.clock.segments}} segments filled\n> \n> **Cause of Advance:**\n\n";
   oraclesFolder: string = "";
+
+  defaultProgressTrackFolder: string = "Progress";
 
   momentumResetTemplate: string =
     "> [!mechanics] {{character.name}} burned momentum: {{oldValue}} -> {{newValue}}\n\n";

--- a/src/settings/ui.ts
+++ b/src/settings/ui.ts
@@ -1,6 +1,7 @@
 import ForgedPlugin from "index";
 import { PluginSettingTab, Setting, type App } from "obsidian";
 import { ForgedPluginSettings } from "settings";
+import { FolderTextSuggest } from "utils/ui/settings/folder";
 
 export class ForgedSettingTab extends PluginSettingTab {
   plugin: ForgedPlugin;
@@ -33,6 +34,19 @@ export class ForgedSettingTab extends PluginSettingTab {
           .setValue(settings.oraclesFolder)
           .onChange((value) => this.updateSetting("oraclesFolder", value)),
       );
+
+    new Setting(containerEl)
+      .setName("Default progress track folder")
+      .setDesc("Create progress tracks in this folder by default.")
+      .addSearch((search) => {
+        new FolderTextSuggest(this.app, search.inputEl);
+        search
+          .setPlaceholder("Type the name of a folder")
+          .setValue(settings.defaultProgressTrackFolder)
+          .onChange((value) =>
+            this.updateSetting("defaultProgressTrackFolder", value),
+          );
+      });
 
     new Setting(containerEl)
       .setName("Use character system")

--- a/src/utils/ui/settings/folder.ts
+++ b/src/utils/ui/settings/folder.ts
@@ -1,0 +1,24 @@
+import { TFolder } from "obsidian";
+import { TextInputSuggest } from "../suggest";
+
+export class FolderTextSuggest extends TextInputSuggest<TFolder> {
+  getSuggestions(inputStr: string): TFolder[] {
+    const searchStr = inputStr.toLowerCase();
+
+    return this.app.vault
+      .getAllLoadedFiles()
+      .filter(
+        (file): file is TFolder =>
+          file instanceof TFolder &&
+          file.path.toLowerCase().contains(searchStr),
+      );
+  }
+  renderSuggestion(folder: TFolder, el: HTMLElement): void {
+    el.setText(folder.path);
+  }
+  selectSuggestion(item: TFolder): void {
+    this.inputEl.value = item.path;
+    this.inputEl.trigger("input");
+    this.close();
+  }
+}

--- a/src/utils/ui/settings/generic-text-suggest.ts
+++ b/src/utils/ui/settings/generic-text-suggest.ts
@@ -1,0 +1,53 @@
+import { App, FuzzyMatch, prepareFuzzySearch } from "obsidian";
+import { processMatches } from "utils/suggest";
+import { TextInputSuggest } from "../suggest";
+
+export class GenericTextSuggest extends TextInputSuggest<FuzzyMatch<string>> {
+  constructor(
+    app: App,
+    inputEl: HTMLInputElement,
+    public readonly items: string[],
+  ) {
+    super(app, inputEl);
+  }
+
+  getSuggestions(inputStr: string): FuzzyMatch<string>[] {
+    const searchFn = prepareFuzzySearch(inputStr);
+    return this.items
+      .flatMap((item) => {
+        const match = searchFn(item);
+        if (match) {
+          return [{ item, match }];
+        } else {
+          return [];
+        }
+      })
+      .sort((a, b) => a.match.score - b.match.score);
+  }
+
+  renderSuggestion({ item, match }: FuzzyMatch<string>, el: HTMLElement): void {
+    if (item == null) return;
+
+    el.createDiv(undefined, (div) => {
+      processMatches(
+        item,
+        match,
+        (text) => {
+          div.appendText(text);
+        },
+        (text) => {
+          div.createEl("strong", { text });
+        },
+      );
+    });
+    // if (renderExtras != null) {
+    //   renderExtras(match, el);
+    // }
+  }
+
+  selectSuggestion({ item }: FuzzyMatch<string>): void {
+    this.inputEl.value = item;
+    this.inputEl.trigger("input");
+    this.close();
+  }
+}


### PR DESCRIPTION
Fixes #46

Adopts the following pattern which we can eventually use for other creators if we like it

- You can set a "default progress track folder" in the settings. This defaults to the old value of "Progress"
- In the Progress track creation modal, you can pick an alternative folder to put this particular track into. I thought this might be helpful if you wanted to organize your tracks by, i dunno, type or location
- In any event, if the folder you specify does not exist, it will be created
